### PR TITLE
Fix infinite blocking issue

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyper_cgi"
-version = "0.2.0"
+version = "0.1.3"
 authors = ["Christian Schilling <christian.schilling@esrlabs.com>", "Louis-Marie Givel <louis-marie.givel@esrlabs.com>"]
 edition = "2018"
 license-file = "LICENSE"
@@ -12,10 +12,21 @@ readme = "README.md"
 
 [dependencies]
 futures = "0.3"
-tokio = {version = "0.3", features = ["full"] }
-tokio-util = { version = "0.4", features=["compat"] }
+tokio = {version = "0.2", features = ["full"] }
+tokio-util = { version = "0.3", features=["compat"] }
 hyper = "0.13"
+
+clap = {version = "2", optional = true }
+base64 = {version = "*", optional = true }
+lazy_static = {version = "1.4", optional = true}
 
 [lib]
 name = "hyper_cgi"
 path = "src/hyper_cgi.rs"
+
+[features]
+test-server = ["clap", "base64", "lazy_static"]
+
+[[bin]]
+name = "hyper-cgi-test-server"
+required-features = ["test-server"]

--- a/src/bin/hyper-cgi-test-server.rs
+++ b/src/bin/hyper-cgi-test-server.rs
@@ -1,0 +1,189 @@
+#[macro_use]
+extern crate lazy_static;
+use futures::FutureExt;
+
+#[macro_export]
+macro_rules! some_or {
+    ($e:expr, $b:block) => {
+        if let Some(x) = $e {
+            x
+        } else {
+            $b
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! ok_or {
+    ($e:expr, $b:block) => {
+        if let Ok(x) = $e {
+            x
+        } else {
+            $b
+        }
+    };
+}
+
+lazy_static! {
+    static ref ARGS: clap::ArgMatches<'static> = parse_args();
+}
+
+pub struct ServerState {
+    username: String,
+    password: String,
+}
+
+pub fn parse_auth(req: &hyper::Request<hyper::Body>) -> Option<(String, String)> {
+    let line = some_or!(
+        req.headers()
+            .get("authorization")
+            .and_then(|h| Some(h.as_bytes())),
+        {
+            return None;
+        }
+    );
+    let u = ok_or!(String::from_utf8(line[6..].to_vec()), {
+        return None;
+    });
+    let decoded = ok_or!(base64::decode(&u), {
+        return None;
+    });
+    let s = ok_or!(String::from_utf8(decoded), {
+        return None;
+    });
+    if let [username, password] = s.as_str().split(':').collect::<Vec<_>>().as_slice() {
+        return Some((username.to_string(), password.to_string()));
+    }
+    return None;
+}
+
+fn auth_response(
+    req: &hyper::Request<hyper::Body>,
+    username: &str,
+    password: &str,
+) -> Option<hyper::Response<hyper::Body>> {
+    let (rusername, rpassword) = match parse_auth(req) {
+        Some(x) => x,
+        None => {
+            println!("no credentials in request");
+            let builder = hyper::Response::builder()
+                .header("WWW-Authenticate", "Basic realm=User Visible Realm")
+                .status(hyper::StatusCode::UNAUTHORIZED);
+            return Some(builder.body(hyper::Body::empty()).unwrap());
+        }
+    };
+
+    if rusername != "admin" && (rusername != username || rpassword != password) {
+        println!("ServerState: wrong user/pass");
+        println!("user: {:?} - {:?}", rusername, username);
+        println!("pass: {:?} - {:?}", rpassword, password);
+        let builder = hyper::Response::builder()
+            .header("WWW-Authenticate", "Basic realm=User Visible Realm")
+            .status(hyper::StatusCode::UNAUTHORIZED);
+        return Some(
+            builder
+                .body(hyper::Body::empty())
+                .unwrap_or(hyper::Response::default()),
+        );
+    }
+
+    println!("CREDENTIALS OK {:?} {:?}", &rusername, &rpassword);
+    return None;
+}
+
+async fn call(
+    serv: std::sync::Arc<ServerState>,
+    req: hyper::Request<hyper::Body>,
+) -> hyper::Response<hyper::Body> {
+    println!("call");
+
+    /* if let Some(response) = auth_response(&req, &serv.username, &serv.password) { */
+    /*     return response; */
+    /* } */
+
+    let workdir =
+        std::path::PathBuf::from(ARGS.value_of("dir").expect("missing working directory"));
+
+    let mut cmd = tokio::process::Command::new(ARGS.value_of("cmd").expect("missing cmd"));
+
+    for arg in ARGS.values_of("args").unwrap() {
+        cmd.arg(&arg);
+    }
+    cmd.current_dir(&workdir);
+    cmd.env("PATH_INFO", req.uri().path());
+
+    hyper_cgi::do_cgi(req, cmd).await.0
+}
+
+#[tokio::main]
+async fn main() {
+    let username = ""; //ARGS.value_of("username").expect("missing username");
+    let password = ""; //ARGS.value_of("password").expect("missing password");
+    let server_state = std::sync::Arc::new(ServerState {
+        username: username.to_owned(),
+        password: password.to_owned(),
+    });
+
+    let make_service = hyper::service::make_service_fn(move |_| {
+        let server_state = server_state.clone();
+
+        let service = hyper::service::service_fn(move |_req| {
+            let server_state = server_state.clone();
+
+            call(server_state, _req).map(Ok::<_, hyper::http::Error>)
+        });
+
+        futures::future::ok::<_, hyper::http::Error>(service)
+    });
+
+    let addr = format!(
+        "0.0.0.0:{}",
+        ARGS.value_of("port").unwrap_or("8000").to_owned()
+    )
+    .parse()
+    .unwrap();
+    let server = hyper::Server::bind(&addr).serve(make_service);
+    println!("Now listening on {}", addr);
+
+    if let Err(e) = server.await {
+        eprintln!("server error: {}", e);
+    }
+}
+
+fn parse_args() -> clap::ArgMatches<'static> {
+    let args = {
+        let mut args = vec![];
+        for arg in std::env::args() {
+            args.push(arg);
+        }
+        args
+    };
+
+    println!("ARGS {:?}", args);
+
+    println!("args: {:?}", args);
+
+    let app = clap::App::new("hyper-cgi-test-server")
+        .arg(clap::Arg::with_name("dir").long("dir").takes_value(true))
+        .arg(clap::Arg::with_name("cmd").long("cmd").takes_value(true))
+        .arg(
+            clap::Arg::with_name("args")
+                .long("args")
+                .short("a")
+                .takes_value(true)
+                .multiple(true),
+        )
+        .arg(clap::Arg::with_name("port").long("port").takes_value(true))
+        .arg(
+            clap::Arg::with_name("password")
+                .long("password")
+                .takes_value(true),
+        )
+        .arg(
+            clap::Arg::with_name("username")
+                .long("username")
+                .takes_value(true),
+        );
+
+    app.get_matches_from(args)
+}


### PR DESCRIPTION
For some requests, in particular very large ones, do_cgi() blocked
indefinitely.
The problem was:

stderr.read_to_end(err_output).await.unwrap_or(0);
stdout.read_to_end(&mut data).await.unwrap_or(0);

The CGI script is not guaranteed to close it's handles in any
particular order but this code requires it to first close stderr,
before it will go and read from stdout.
In the case of a very large response the internal buffer for stdout
would fill up causing the CGI script to blocked and never reaching
the point where it would close stderr (because it will only close
stderr once it has completed writing all output to stdout, which it
can't because nobody is reading and the buffer is full).

The solution is to read stderr and stdout concurrently and waiting
for both to complete with try_join!()

This also adds an optionally compiled binary for testing and adjusts
the version number.