### PR TITLE
Read/Write concurrently

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ hyper = "0.13"
 
 clap = {version = "2", optional = true }
 base64 = {version = "0.13", optional = true }
+rand = {version = "0.5", optional = true }
 lazy_static = {version = "1.4", optional = true}
 
 [lib]
@@ -25,7 +26,7 @@ name = "hyper_cgi"
 path = "src/hyper_cgi.rs"
 
 [features]
-test-server = ["clap", "base64", "lazy_static"]
+test-server = ["clap", "base64", "lazy_static", "rand"]
 
 [[bin]]
 name = "hyper-cgi-test-server"


### PR DESCRIPTION
Previously do_cgi would wait until the request data is written
completely before starting to read stdout and stderr.
Now all three operations are overlapped.

Also add auth support to the test server.